### PR TITLE
Add area click points, etc

### DIFF
--- a/needly/needly/needly.py
+++ b/needly/needly/needly.py
@@ -656,6 +656,20 @@ class Application:
 
     def show_connect_VM(self, event=None):
         """ Show a dialogue to connect to a VM """
+        # Get the domain names from the kvm hypervisor
+        domains = []
+        try:
+            self.kvm = libvirt.open("qemu:///session")
+            # Get the names of all running domains in the hypervisor.
+            domains = [x.name() for x in self.kvm.listAllDomains()]
+        except libvirt.libvirtError:
+            messagebox.showerror("Error", "Failed to open connection to the hypervisor.")
+            return
+
+        if not domains:
+            messagebox.showerror("No domains found", "Either the hypervisor is not running or no VMs available in the qemu:///session.")
+            return
+
         # Create the basic GUI for the dialogue
         self.connect_dialogue = tk.Toplevel(self.toplevel)
         self.connect_dialogue.title('Connect to a VM')
@@ -667,20 +681,9 @@ class Application:
         choices = tk.StringVar()
         self.cd_choose_box = ttk.Combobox(self.cd_layout, textvariable=choices, height=3)
         self.cd_choose_box.grid(row=0, column=1)
+        self.cd_choose_box['values'] = domains
         self.cd_connect = tk.Button(self.cd_layout, text="Connect", width=10, command=self.connect)
         self.cd_connect.grid(row=1, column=1)
-
-        # Get the domain names from the kvm hypervisor
-        try:
-            self.kvm = libvirt.open("qemu:///session")
-            # Get the names of all running domains in the hypervisor.
-            domains = [x.name() for x in self.kvm.listAllDomains()]
-            if len(domains) == 0:
-                messagebox.showerror("No domains found", "Either the hypervisor is not running or no VMs available in the qemu:///session.")
-            self.cd_choose_box['values'] = domains
-        except libvirt.libvirtError:
-            messagebox.showerror("Error", "Failed to open connection to the hypervisor.")
-            self.cd_choose_box['values'] = []
 
     def connect(self, event=None):
         """ Update the status variable to let the application know about the VM. """

--- a/needly/needly/needly.py
+++ b/needly/needly/needly.py
@@ -222,11 +222,11 @@ class Application:
         self.widthEntry = tk.Entry(self.coordFrame, width=5)
         self.widthEntry.grid(row=0, column=5, sticky="w")
 
-        self.heigthLabel = tk.Label(self.coordFrame, text="Area heigth:")
-        self.heigthLabel.grid(row=1, column=4, sticky="w")
+        self.heightLabel = tk.Label(areaFrame, text="Area height:")
+        self.heightLabel.grid(row=1, column=4, sticky="w")
 
-        self.heigthEntry = tk.Entry(self.coordFrame, width=5)
-        self.heigthEntry.grid(row=1, column=5, sticky="w")
+        self.heightEntry = tk.Entry(areaFrame, width=5)
+        self.heightEntry.grid(row=1, column=5, sticky="w")
 
         self.bxLable = tk.Label(self.coordFrame, text="X2:")
         self.bxLable.grid(row=1, column=0, sticky="w")
@@ -402,8 +402,8 @@ class Application:
     def calculateSize(self, coordinates):
         """Calculate size of the area from its coordinates."""
         width = int(coordinates[2]) - int(coordinates[0])
-        heigth = int(coordinates[3]) - int(coordinates[1])
-        return [width, heigth]
+        height = int(coordinates[3]) - int(coordinates[1])
+        return [width, height]
 
     def showArea(self, event=None):
         """Load area and draw a rectangle around it."""
@@ -443,8 +443,8 @@ class Application:
         size = self.calculateSize(coordinates)
         self.widthEntry.delete(0, "end")
         self.widthEntry.insert("end", size[0])
-        self.heigthEntry.delete(0, "end")
-        self.heigthEntry.insert("end", size[1])
+        self.heightEntry.delete(0, "end")
+        self.heightEntry.insert("end", size[1])
 
     def modifyArea(self, event=None):
         """Update the information for the active needle area, including properties, tags, etc."""

--- a/needly/needly/needly.py
+++ b/needly/needly/needly.py
@@ -596,7 +596,8 @@ class Application:
         if self.imageName is not None:
             jsonfile = self.returnPath(self.imageName).replace(".png", ".json")
             self.handler = fileHandler(jsonfile)
-            self.handler.readFile()
+            if not self.handler.readFile():
+                return
             jsondata = self.handler.provideData()
             self.needle = needleData(jsondata)
             properties = self.needle.provideProperties()
@@ -774,14 +775,19 @@ class fileHandler:
 
     def readFile(self):
         """Read the json file and create the data variable with the info."""
+        success = False
         try:
             with open(self.jsonfile, "r") as inFile:
                 self.jsonData = json.load(inFile)
+                success = True
         except FileNotFoundError:
             if self.jsonfile != "empty":
                 messagebox.showerror("Error", "No needle exists. Create one.")
             else:
                 messagebox.showerror("Error", "No images are loaded. Select image directory.")
+        except json.JSONDecodeError as e:
+            messagebox.showerror("Error", f"Failed to load JSON.\n\n{e}")
+        return success
 
     def writeFile(self, jsonfile):
         """Take the data variable and write is out as a json file."""

--- a/needly/needly/needly.py
+++ b/needly/needly/needly.py
@@ -204,81 +204,82 @@ class Application:
         self.propText = tk.Text(self.jsonFrame, width=30, height=4)
         self.propText.grid(row=3, column=0, sticky="ew")
 
-        self.needleUL = tk.Label(self.jsonFrame, text="Area Coordinates:")
-        self.needleUL.grid(row=4, column=0, sticky="w")
+        areaFrame = tk.LabelFrame(self.jsonFrame, text="Area", padx=5, pady=5)
+        areaFrame.grid(row=4, column=0, sticky="ew")
 
-        self.coordFrame = tk.Frame(self.jsonFrame)
-        self.coordFrame.grid(row=5, column=0, sticky="ew")
+        self.needleUL = tk.Label(areaFrame, text="Coordinates:")
+        self.needleUL.grid(row=0, column=0, columnspan=2, sticky="w")
 
-        self.axLable = tk.Label(self.coordFrame, text="X1:")
-        self.axLable.grid(row=0, column=0, sticky="w")
+        self.axLabel = tk.Label(areaFrame, text="X1:")
+        self.axLabel.grid(row=1, column=0, sticky="w")
 
-        self.axEntry = tk.Entry(self.coordFrame, width=5)
-        self.axEntry.grid(row=0, column=1, sticky="w")
+        self.axEntry = tk.Entry(areaFrame, width=5)
+        self.axEntry.grid(row=1, column=1, sticky="w")
 
-        self.ayLable = tk.Label(self.coordFrame, text="Y1:")
-        self.ayLable.grid(row=0, column=2, sticky="w")
+        self.ayLabel = tk.Label(areaFrame, text="Y1:")
+        self.ayLabel.grid(row=1, column=2, sticky="w")
 
-        self.ayEntry = tk.Entry(self.coordFrame, width=5)
-        self.ayEntry.grid(row=0, column=3, sticky="w")
+        self.ayEntry = tk.Entry(areaFrame, width=5)
+        self.ayEntry.grid(row=1, column=3, sticky="w")
 
-        self.widthLabel = tk.Label(self.coordFrame, text="Area width:")
-        self.widthLabel.grid(row=0, column=4, sticky="w")
+        self.widthLabel = tk.Label(areaFrame, text="Width:")
+        self.widthLabel.grid(row=1, column=4, sticky="w")
 
-        self.widthEntry = tk.Entry(self.coordFrame, width=5)
-        self.widthEntry.grid(row=0, column=5, sticky="w")
+        self.widthEntry = tk.Entry(areaFrame, width=5)
+        self.widthEntry.grid(row=1, column=5, sticky="w")
         self.widthEntry.config(state="readonly")
 
-        self.bxLable = tk.Label(self.coordFrame, text="X2:")
-        self.bxLable.grid(row=1, column=0, sticky="w")
+        self.bxLabel = tk.Label(areaFrame, text="X2:")
+        self.bxLabel.grid(row=2, column=0, sticky="w")
 
-        self.bxEntry = tk.Entry(self.coordFrame, width=5)
-        self.bxEntry.grid(row=1, column=1, sticky="w")
+        self.bxEntry = tk.Entry(areaFrame, width=5)
+        self.bxEntry.grid(row=2, column=1, sticky="w")
 
-        self.byLable = tk.Label(self.coordFrame, text="Y2:")
-        self.byLable.grid(row=1, column=2, sticky="w")
+        self.byLabel = tk.Label(areaFrame, text="Y2:")
+        self.byLabel.grid(row=2, column=2, sticky="w")
 
-        self.byEntry = tk.Entry(self.coordFrame, width=5)
-        self.byEntry.grid(row=1, column=3, sticky="w")
+        self.byEntry = tk.Entry(areaFrame, width=5)
+        self.byEntry.grid(row=2, column=3, sticky="w")
 
-        self.heightLabel = tk.Label(self.coordFrame, text="Area height:")
-        self.heightLabel.grid(row=1, column=4, sticky="w")
+        self.heightLabel = tk.Label(areaFrame, text="Height:")
+        self.heightLabel.grid(row=2, column=4, sticky="w")
 
-        self.heightEntry = tk.Entry(self.coordFrame, width=5)
-        self.heightEntry.grid(row=1, column=5, sticky="w")
+        self.heightEntry = tk.Entry(areaFrame, width=5)
+        self.heightEntry.grid(row=2, column=5, sticky="w")
         self.heightEntry.config(state="readonly")
 
         self.listLabel = tk.Label(self.jsonFrame, text="Area type:")
         self.listLabel.grid(row=6, column=0, sticky="w")
+        self.listLabel = tk.Label(areaFrame, text="Type:")
+        self.listLabel.grid(row=3, column=0, columnspan=6, sticky="w")
 
-        self.typeList = tk.Spinbox(self.jsonFrame, values=["match","ocr","exclude"])
-        self.typeList.grid(row=7, column=0, sticky="ew")
+        self.typeList = tk.Spinbox(areaFrame, values=["match","ocr","exclude"])
+        self.typeList.grid(row=4, column=0, columnspan=6, sticky="ew")
 
-        self.matchLabel = tk.Label(self.jsonFrame, text="Match level:")
-        self.matchLabel.grid(row=8, column=0, sticky="w")
+        self.matchLabel = tk.Label(areaFrame, text="Match level:")
+        self.matchLabel.grid(row=5, column=0, columnspan=6, sticky="w")
 
-        self.matchEntry = tk.Entry(self.jsonFrame, width=30)
-        self.matchEntry.grid(row=9, column=0, sticky="ew")
+        self.matchEntry = tk.Entry(areaFrame, width=30)
+        self.matchEntry.grid(row=6, column=0, columnspan=6, sticky="ew")
+
+
+
+
+
+
+        self.areaFrame = areaFrame
 
         self.textLabel = tk.Label(self.jsonFrame, text="Tags:")
-        self.textLabel.grid(row=10, column=0, sticky="w")
+        self.textLabel.grid(row=5, column=0, sticky="w")
 
         self.textField = tk.Text(self.jsonFrame, width=30, height=3)
-        self.textField.grid(row=11, column=0, sticky="ew")
-
-
-
-        self.needleLabel = tk.Label(self.jsonFrame, text="Areas in needle: ")
-        self.needleLabel.grid(row=14, column=0, sticky="w")
-
-        self.needleEntry = tk.Entry(self.jsonFrame, width=30)
-        self.needleEntry.grid(row=15, column=0, sticky="ew")
+        self.textField.grid(row=6, column=0, sticky="ew")
 
         self.vmLabel = tk.Label(self.jsonFrame, text="VM connection:")
-        self.vmLabel.grid(row=16, column=0, sticky="w")
+        self.vmLabel.grid(row=7, column=0, sticky="w")
 
         self.vmEntry = tk.Entry(self.jsonFrame, width=30)
-        self.vmEntry.grid(row=17, column=0, sticky="ew")
+        self.vmEntry.grid(row=8, column=0, sticky="ew")
         self.vmEntry.insert("end","Not connected")
         self.vmEntry.config(state="readonly")
 
@@ -430,6 +431,7 @@ class Application:
             if match:
                 self.matchEntry.delete(0, "end")
                 self.matchEntry.insert("end", match)
+            self.updateCurrentAreaLabel()
         except TypeError:
             for r in self.rectangles:
                 self.pictureField.delete(r)
@@ -489,20 +491,19 @@ class Application:
         """Add new area to needle. The needle can have more areas."""
         self.needle.addArea()
         self.modifyArea(None)
-        areas = self.needle.provideAreaCount()
-        self.needleEntry.delete(0, "end")
-        self.needleEntry.insert("end", areas)
 
+    def updateCurrentAreaLabel(self):
+        """Update current area to area frame."""
+        position = self.needle.provideCurrentAreaLabel()
+        self.areaFrame["text"] = f"Area {position}"
 
     def removeAreaFromNeedle(self, event=None):
         """Remove the active area from the needle (deletes it)."""
         self.needle.removeArea()
-        areas = self.needle.provideAreaCount()
         coordinates = [0, 0, 0, 0]
         self.displayCoordinates(coordinates)
-        self.needleEntry.delete(0, "end")
-        self.needleEntry.insert("end", areas)
         self.pictureField.delete(self.rectangle)
+        self.updateCurrentAreaLabel()
         self.updateDebugJson()
         self.showArea(None)
 
@@ -610,10 +611,8 @@ class Application:
             tags = self.needle.provideTags()
             self.textField.delete("1.0", "end")
             self.textField.insert("end", tags)
-            areas = self.needle.provideAreaCount()
-            self.needleEntry.delete(0, "end")
-            self.needleEntry.insert(0, areas)
             self.updateDebugJson()
+            self.updateCurrentAreaLabel()
             if self.rectangle is not None:
                 self.pictureField.delete(self.rectangle)
                 self.rectangle = None
@@ -749,10 +748,10 @@ class Application:
             return
 
         self.jsonLabel = tk.Label(self.jsonFrame, text="JSON Data:")
-        self.jsonLabel.grid(row=19, column=0, sticky="w")
+        self.jsonLabel.grid(row=9, column=0, sticky="w")
 
         self.textJson = tk.Text(self.jsonFrame, width=30, height=8)
-        self.textJson.grid(row=20, column=0, sticky="ew")
+        self.textJson.grid(row=10, column=0, sticky="ew")
         self.textJson.config(state="disabled")
 
         self.updateDebugJson()
@@ -903,9 +902,9 @@ class needleData:
         except IndexError:
             messagebox.showerror("Error", "No area in the needle. Not deleting anything.")
 
-    def provideAreaCount(self):
-        """Provide the number of the areas in the needle."""
-        return len(self.areas)
+    def provideCurrentAreaLabel(self):
+        """Provide the current area label."""
+        return f"{self.areaPos}/{len(self.areas)}"
 
 
 #-----------------------------------------------------------------------------------------------

--- a/needly/needly/needly.py
+++ b/needly/needly/needly.py
@@ -117,13 +117,21 @@ class Application:
     def acceptCliChoice(self, path):
         """Opens an image for editing when passed as a CLI argument upon starting the editor."""
         self.directory = os.path.dirname(path)
-        image = os.path.basename(path)
+        filename = os.path.basename(path)
+        if filename.endswith('.json'):
+            chunks = filename.split('.')
+            self.imageName = '.'.join(chunks[:-1]) + '.png'
+        else:
+            self.imageName = filename
+        self.imageCount = 0
+
+        # Ensure the image is displayed before any areas are rendered
+        image_path = os.path.join(self.directory, self.imageName)
+        self.displayImage(image_path)
+
         # If a json file is opened, we assume that we want to load the needle automatically
         # and that the needle exists, there we will open and load the needle file.
-        if '.json' in image:
-            prefix = image.split('.')[0]
-            image = prefix + '.png'
-            self.imageName = image
+        if filename.endswith('.json'):
             self.loadNeedle()
         else:
             # If however, we start the application with the PNG file, the json needle file
@@ -132,7 +140,6 @@ class Application:
             # If the test fails, we will at least set the tag from the filename
             # to save users some time to type. Users can edit it, later and change the file name
             # from within the application.
-            self.imageName = image
             jfile = os.path.join(self.directory, self.imageName)
             # Let's replace the suffix and test if the file exists.
             pre = jfile.split('.')[0]
@@ -144,9 +151,6 @@ class Application:
                 # Or just prefill the tag field from the file name.
                 tag = self.imageName.split('.')[0]
                 self.textField.insert("end", tag)
-        self.imageCount = 0
-        path = os.path.join(self.directory, self.imageName)
-        self.displayImage(path)
 
     def buildWidgets(self):
         """Construct GUI"""

--- a/needly/needly/needly.py
+++ b/needly/needly/needly.py
@@ -24,7 +24,6 @@ import tkinter as tk
 import io
 import os
 import json
-import re
 import sys
 import libvirt
 from tkinter import ttk
@@ -318,7 +317,7 @@ class Application:
             path = filedialog.askopenfile().name
         except AttributeError:
             noimage = True
-        if noimage == False:
+        if not noimage:
             self.directory = os.path.split(path)[0]
             image = os.path.split(path)[1]
             if 'json' in image:
@@ -357,7 +356,7 @@ class Application:
             else:
                 messagebox.showerror("Error", "No images are loaded. Select an image first.")
                 noimage = True
-        if noimage == False:
+        if not noimage:
             self.pictureField.delete(self.rectangle)
             self.rectangle = None
             self.displayImage(self.returnPath(self.imageName))
@@ -376,7 +375,7 @@ class Application:
             else:
                 messagebox.showerror("Error", "No images are loaded. Select an image first.")
                 noimage = True
-        if noimage == False:
+        if not noimage:
             self.pictureField.delete(self.rectangle)
             self.rectangle = None
             self.displayImage(self.returnPath(self.imageName))
@@ -505,7 +504,7 @@ class Application:
         xpos = int(self.pictureField.canvasx(event.x))
         ypos = int(self.pictureField.canvasy(event.y))
         self.startPoint = [xpos, ypos]
-        if self.rectangle == None:
+        if self.rectangle is None:
             self.rectangle = self.pictureField.create_rectangle(self.needleCoordinates, outline="red", width=2)
 
     def redrawArea(self, event):
@@ -591,7 +590,7 @@ class Application:
 
     def loadNeedle(self, event=None):
         """Load the existing needle information from the file and display them in the window."""
-        if self.imageName != None:
+        if self.imageName is not None:
             jsonfile = self.returnPath(self.imageName).replace(".png", ".json")
             self.handler = fileHandler(jsonfile)
             self.handler.readFile()
@@ -609,7 +608,7 @@ class Application:
             areas = self.needle.provideAreaCount()
             self.needleEntry.delete(0, "end")
             self.needleEntry.insert(0, areas)
-            if self.rectangle != None:
+            if self.rectangle is not None:
                 self.pictureField.delete(self.rectangle)
                 self.rectangle = None
             self.showArea(None)
@@ -621,7 +620,7 @@ class Application:
         jsondata = self.needle.provideJson()
         filename = self.nameEntry.get().replace(".png", ".json")
         path = self.returnPath(filename)
-        if self.handler == None:
+        if self.handler is None:
             self.handler = fileHandler(path)
         self.handler.acceptData(jsondata)
         self.handler.writeFile(path)
@@ -713,7 +712,7 @@ class Application:
             # On a VM usually only one screen is available,
             # so we will take the first one and will not bother
             # about others.
-            image_type = domain.screenshot(stream, 0)
+            domain.screenshot(stream, 0)
             # The stream will be caught in an envelope
             image_data = io.BytesIO()
             # Now, let's take the data from the stream
@@ -836,9 +835,9 @@ class needleData:
         else:
             area = {"xpos":xpos, "ypos":ypos, "width":wide, "height":high, "type":typ}
 
-        if type(props) != list:
+        if not isinstance(props, list):
             props = [props]
-        if type(tags) != list:
+        if not isinstance(tags, list):
             tags = [tags]
         self.jsonData["properties"] = props
         self.jsonData["tags"] = tags
@@ -857,7 +856,7 @@ class needleData:
     def removeArea(self):
         """Remove the active area from the area list."""
         try:
-            deleted = self.areas.pop(self.areaPos-1)
+            self.areas.pop(self.areaPos-1)
             self.jsonData["area"] = self.areas
             self.areaPos -= 2
         except IndexError:
@@ -878,7 +877,7 @@ def main():
 
     app = Application()
 
-    if path != None:
+    if path is not None:
         app.acceptCliChoice(path)
 
     app.run()


### PR DESCRIPTION
As discussed at #7 the main drive behind this was to add the ability to set and modify click points against areas.

There are a number of other changes though, some needed for the click points, others separate (although generally minor). The full commit messages provide some more detail (combined with what I already wrote at #7).

Alternatively there's some ability to break things up into separate PRs.

Two notable changes after writing the issue: 
- `modifyArea` is now (automatically) called upon changing an area's border via the mouse or arrow keys. This improves the flow between updating area borders and providing click points.
- Showing of the JSON output in the sidebar seemed to mainly be useful for debugging, for the developers of Needly? I hid it by default, adding a keyboard shortcut, ctrl-K, to show it.

One thing remains a bit unclear for me as far as the interaction design goes. Navigating needles/images via _Open file_, _Open directory_, _Load next_ and _Load previous_ appear to only load the image file, leaving needle data in whatever state it was in before the image was changed. Which is a bit confusing for the user? 

I haven't made any changes for this as I wasn't sure if it was for some reason intentional. It would seem more intuitive to me to, when changing image, use logic eg. from [here down](https://github.com/cheywood/needly/blob/32e018e4d667199f33113ea83c7a2eb14cd550a6/needly/needly/needly.py#L133) in `acceptCliChoice`. So effectively _Open file_ would do the same as opening a file from CLI (selecting either the JSON or the PNG). Removing separate needle loading would make things clearer for the user.

Without making changes around that it somewhat breaks the concept of always having a (sane) active area.